### PR TITLE
Add CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,22 +14,22 @@ authors:
     affiliation: University College London
     orcid: 'https://orcid.org/0000-0001-9104-7960'
   - given-names: M Jorge
-    family-name: Cardoso
+    family-names: Cardoso
     email: m.jorge.cardoso@kcl.ac.uk
     affiliation: King's College London
     orcid: 'https://orcid.org/0000-0003-1284-2558'
-  - given-name: Sebastien
-    family-name: Ourselin
+  - given-names: Sebastien
+    family-names: Ourselin
     email: sebastien.ourselin@kcl.ac.uk
     affiliation: King's College London
     orcid: 'https://orcid.org/0000-0002-5694-5340'
-  - given-name: Geraint
-    family-name: Rees
+  - given-names: Geraint
+    family-names: Rees
     email: g.rees@ucl.ac.uk
     affiliation: University College London
     orcid: 'https://orcid.org/0000-0002-9623-7007'
-  - given-name: Parashkev
-    family-name: Nachev
+  - given-names: Parashkev
+    family-names: Nachev
     email: p.nachev@ucl.ac.uk
     affiliation: King's College London
     orcid: 'https://orcid.org/0000-0002-2718-4423'


### PR DESCRIPTION
As discussed in meeting on 2022/04/06, this PR adds a [`CITATION.cff`](https://citation-file-format.github.io/) file to the repository to specify how to cite the repository.

For now I have added @r-gray and myself as authors based on the GitHub contributor list. @r-gray let me know if there are additional authors of the initial committed version of the code who should be added: these can either be individuals or research groups [as the Citation File Format allows for listing entities as well as individuals as authors](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#authors).

@r-gray: Do you have an ORCID - searching for Robert Gray at UCL gave https://orcid.org/0000-0001-5035-4999 but not sure if this is you or not?