### PR TITLE
Use typing Dict to retain Python 3.7 and 3.8 compatibility

### DIFF
--- a/scripts/train_vae_model.py
+++ b/scripts/train_vae_model.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 import torch
 from verydeepvae.orchestration import training_script_vae_new as training_script
 
@@ -73,7 +73,7 @@ def parse_command_line_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def post_process_hyperparameters(hyperparameters: dict[str, Any], cli_args: argparse.Namespace):
+def post_process_hyperparameters(hyperparameters: Dict[str, Any], cli_args: argparse.Namespace):
     """Update loaded hyperparameter dictionary in-place using CLI argument values."""
     hyperparameters["model_name"] = cli_args.json_config_file.stem
     hyperparameters["checkpoint_folder"] = str(cli_args.output_dir / "torch_checkpoints")


### PR DESCRIPTION
Use `typing.Dict` in place of in-built `dict` in subscripted type hint to retain Python 3.7 and 3.8 compatibility as using type hinting generics with standard collection was introduced in [PEP 585](https://peps.python.org/pep-0585/) which is in Python 3.9 and later only.