### PR TITLE
Add script to generate synthetic training data

### DIFF
--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -1,0 +1,59 @@
+"""Generate NIfTI images as synthetic training data set."""
+
+import argparse
+import os
+import pathlib
+import numpy as np
+import nibabel as nb
+
+
+def generate_synthetic_image(rng, args):
+    return rng.uniform(0, 1, size=(args.voxels_per_axis,) * 3)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        "Generate NIfTI volumetric images as synthetic training data set",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--voxels_per_axis",
+        type=int,
+        default=32,
+        help="The number of voxels along each of the three spatial axes",
+    )
+    parser.add_argument(
+        "--number_of_files",
+        type=int,
+        default=1000,
+        help="The number of NIfTI files to generate",
+    )
+    parser.add_argument(
+        "--random_seed",
+        type=int,
+        default=None,
+        help="Integer seed to use to initialise pseudo-random number generator state",
+    )
+    parser.add_argument(
+        "--output_directory",
+        type=pathlib.Path,
+        required=True,
+        help="The directory to write the generated files to",
+    )
+    args = parser.parse_args()
+    affine_transformation = np.identity(4)
+    if not args.output_directory.exists():
+        os.makedirs(args.output_directory)
+    if args.number_of_files <= 0:
+        raise ValueError("number_of_files must be a positive integer")
+    if args.voxels_per_axis <= 0 or (np.log2(args.voxels_per_axis) % 1) != 0.0:
+        raise ValueError("voxels_per_image must be a positive power of two")
+    rng = np.random.default_rng(args.random_seed)
+    for i in range(args.number_of_files):
+        voxels = generate_synthetic_image(rng, args)
+        nifti_image = nb.Nifti1Image(voxels, affine_transformation)
+        nb.save(nifti_image, args.output_directory / f"generated_{i}.nii")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -92,10 +92,11 @@ def main():
     if args.voxels_per_axis <= 0 or (np.log2(args.voxels_per_axis) % 1) != 0.0:
         raise ValueError("voxels_per_image must be a positive power of two")
     rng = np.random.default_rng(args.random_seed)
-    for i in range(args.number_of_files):
+    for file_index in range(args.number_of_files):
         voxels = generate_synthetic_voxels(rng, args)
         nifti_image = nb.Nifti1Image(voxels, affine_transformation)
-        nb.save(nifti_image, args.output_directory / f"generated_{i}.nii")
+        padded_index = str(file_index).zfill(len(str(args.number_of_files - 1)))
+        nb.save(nifti_image, args.output_directory / f"ellipsoid_{padded_index}.nii")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -5,15 +5,39 @@ import os
 import pathlib
 import numpy as np
 import nibabel as nb
+from scipy.ndimage import gaussian_filter
 
 
-def generate_synthetic_image(rng, args):
-    return rng.uniform(0, 1, size=(args.voxels_per_axis,) * 3)
+def generate_synthetic_voxels(rng, args):
+    shape = (args.voxels_per_axis,) * 3
+    voxels = gaussian_filter(
+        rng.uniform(0, args.background_noise_amplitude, size=shape),
+        sigma=args.background_noise_length_scale,
+    )
+    principle_axes_half_lengths = rng.integers(
+        low=max(1, args.voxels_per_axis // 8),
+        high=max(1, args.voxels_per_axis // 2),
+        size=3,
+        endpoint=True,
+    )
+    random_rotation_matrix, _ = np.linalg.qr(rng.standard_normal((3, 3)))
+    voxel_coords = np.stack(
+        np.meshgrid(*((np.arange(args.voxels_per_axis),) * 3), indexing="ij"), axis=-1
+    ) - np.array(((args.voxels_per_axis - 1) / 2,) * 3)
+    rotated_voxel_coords = voxel_coords @ random_rotation_matrix
+    ellipse_mask = (
+        np.sum(rotated_voxel_coords ** 2 / principle_axes_half_lengths ** 2, -1) < 1
+    )
+    voxels[ellipse_mask] += rng.uniform(*args.ellipsoid_increment_interval)
+    voxels /= voxels.max()
+    assert np.all((voxels >= 0) & (voxels <= 1))
+    return voxels
 
 
 def main():
     parser = argparse.ArgumentParser(
-        "Generate NIfTI volumetric images as synthetic training data set",
+        "Generate random ellipsoid inclusion in background noise NIfTI volumetric "
+        "images as synthetic training data set",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -40,6 +64,25 @@ def main():
         required=True,
         help="The directory to write the generated files to",
     )
+    parser.add_argument(
+        "--background_noise_amplitude",
+        type=float,
+        default=0.05,
+        help="The amplitude in [0, 1] of the (pre-filtering) background noise",
+    )
+    parser.add_argument(
+        "--background_noise_length_scale",
+        type=float,
+        default=0.5,
+        help="Length-scale parameter (in voxels) of Gaussian filter applied to noise",
+    )
+    parser.add_argument(
+        "--ellipsoid_increment_interval",
+        type=float,
+        nargs=2,
+        default=[0.25, 0.75],
+        help="The interval the value added to ellipsoid voxels is uniformly drawn from",
+    )
     args = parser.parse_args()
     affine_transformation = np.identity(4)
     if not args.output_directory.exists():
@@ -50,7 +93,7 @@ def main():
         raise ValueError("voxels_per_image must be a positive power of two")
     rng = np.random.default_rng(args.random_seed)
     for i in range(args.number_of_files):
-        voxels = generate_synthetic_image(rng, args)
+        voxels = generate_synthetic_voxels(rng, args)
         nifti_image = nb.Nifti1Image(voxels, affine_transformation)
         nb.save(nifti_image, args.output_directory / f"generated_{i}.nii")
 

--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -5,8 +5,8 @@ import os
 import pathlib
 import numpy as np
 import nibabel as nb
+import tqdm
 from scipy.ndimage import gaussian_filter
-
 
 def generate_synthetic_voxels(rng, args):
     shape = (args.voxels_per_axis,) * 3
@@ -92,7 +92,7 @@ def main():
     if args.voxels_per_axis <= 0 or (np.log2(args.voxels_per_axis) % 1) != 0.0:
         raise ValueError("voxels_per_image must be a positive power of two")
     rng = np.random.default_rng(args.random_seed)
-    for file_index in range(args.number_of_files):
+    for file_index in tqdm.trange(args.number_of_files):
         voxels = generate_synthetic_voxels(rng, args)
         nifti_image = nb.Nifti1Image(voxels, affine_transformation)
         padded_index = str(file_index).zfill(len(str(args.number_of_files - 1)))

--- a/scripts/train_vae_model.py
+++ b/scripts/train_vae_model.py
@@ -25,7 +25,17 @@ def parse_command_line_arguments() -> argparse.Namespace:
         "--nifti_flair_dir", 
         type=Path,
         required=True,
-        help="Path to directory containing FLAIR image NiFTI files to train model with"
+        help="Path to directory containing FLAIR image NIfTI files to train model with",
+    )
+    parser.add_argument(
+        "--nifti_flair_pattern",
+        type=str,
+        default="*_flair.nii",
+        help=(
+            "Filename pattern for NIfTI image files to train model with. * matches "
+            "everything, ? matches any single character, [seq] matches any character "
+            "in seq, [!seq] matches any character not in seq"
+        ),
     )
     parser.add_argument(
         "--output_dir", 
@@ -81,12 +91,13 @@ def post_process_hyperparameters(hyperparameters: Dict[str, Any], cli_args: argp
     hyperparameters["recon_folder"] = str(cli_args.output_dir / "reconstructions")
     for key in [
         "nifti_flair_dir", 
+        "nifti_flair_pattern",
         "CUDA_devices", 
         "local_rank", 
         "master_addr", 
         "master_port", 
         "workers_per_process", 
-        "threads_per_rank"
+        "threads_per_rank",
     ]:
         hyperparameters[key] = getattr(cli_args, key)
     # For hyperparameters which require specifying a boolean flag per channel or latent 
@@ -118,7 +129,9 @@ def main():
     if not cli_args.nifti_flair_dir.exists():
         raise ValueError(f"nift_flair_dir {cli_args.nifti_flair_dir} does not exist")
     if not cli_args.nifti_flair_dir.is_dir():
-        raise ValueError(f"nift_flair_dir {cli_args.nifti_flair_dir} is not a directory")
+        raise ValueError(
+            f"nifti_flair_dir {cli_args.nifti_flair_dir} is not a directory"
+        )
     if not cli_args.output_dir.exists():
         os.makedirs(cli_args.output_dir)
     with open(cli_args.json_config_file, "r") as f:

--- a/scripts/train_vae_model.py
+++ b/scripts/train_vae_model.py
@@ -30,7 +30,7 @@ def parse_command_line_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--nifti_filename_pattern",
         type=str,
-        default="*_flair.nii",
+        default="*.nii",
         help=(
             "Pattern for names of NIfTI files to use to train and validate model. * "
             "matches everything, ? matches any single character, [seq] matches any  "

--- a/scripts/train_vae_model.py
+++ b/scripts/train_vae_model.py
@@ -22,13 +22,13 @@ def parse_command_line_arguments() -> argparse.Namespace:
         help="Path to JSON file specifying model and run hyperparameters"
     )
     parser.add_argument(
-        "--nifti_flair_dir",
+        "--nifti_dir",
         type=Path,
         required=True,
         help="Path to directory containing NIfTI files to train & validate model with",
     )
     parser.add_argument(
-        "--nifti_flair_pattern",
+        "--nifti_filename_pattern",
         type=str,
         default="*_flair.nii",
         help=(
@@ -95,8 +95,8 @@ def post_process_hyperparameters(
     hyperparameters["tensorboard_dir"] = str(cli_args.output_dir / "tensorboard")
     hyperparameters["recon_folder"] = str(cli_args.output_dir / "reconstructions")
     for key in [
-        "nifti_flair_dir",
-        "nifti_flair_pattern",
+        "nifti_dir",
+        "nifti_filename_pattern",
         "CUDA_devices",
         "local_rank",
         "master_addr",
@@ -133,11 +133,11 @@ def main():
     cli_args = parse_command_line_arguments()
     if not cli_args.json_config_file.exists():
         raise ValueError(f"No configuration file found at {cli_args.json_config_file}")
-    if not cli_args.nifti_flair_dir.exists():
-        raise ValueError(f"nift_flair_dir {cli_args.nifti_flair_dir} does not exist")
-    if not cli_args.nifti_flair_dir.is_dir():
+    if not cli_args.nifti_dir.exists():
+        raise ValueError(f"nifti_dir {cli_args.nifti_dir} does not exist")
+    if not cli_args.nifti_dir.is_dir():
         raise ValueError(
-            f"nifti_flair_dir {cli_args.nifti_flair_dir} is not a directory"
+            f"nifti_dir {cli_args.nifti_dir} is not a directory"
         )
     if not cli_args.output_dir.exists():
         os.makedirs(cli_args.output_dir)

--- a/verydeepvae/orchestration/training_script_vae_new.py
+++ b/verydeepvae/orchestration/training_script_vae_new.py
@@ -76,16 +76,16 @@ def main(hyper_params):
             elif hyper_params['sequence_type'] == 'flair':
                 filenames_flair = checkpoint['filenames_flair']
                 misc.print_0(hyper_params, "Number of niftis: " + str(len(filenames_flair)))
-                nifti_paths_flair = [hyper_params['nifti_flair_dir'] / name for name in filenames_flair]
+                nifti_paths_flair = [hyper_params['nifti_dir'] / name for name in filenames_flair]
                 nifti_b1000_filenames = filenames_flair
                 nifti_b1000_paths = nifti_paths_flair
         else:
             misc.print_0(hyper_params, "Sequence type: " + hyper_params['sequence_type'])
-            misc.print_0(hyper_params, f"nifti_flair_dir found in hyper_params: {hyper_params['nifti_flair_dir']}")
+            misc.print_0(hyper_params, f"nifti_dir found in hyper_params: {hyper_params['nifti_dir']}")
             nifti_paths_flair = glob.glob(
                 str(
-                    hyper_params['nifti_flair_dir'] 
-                    / hyper_params["nifti_flair_pattern"]
+                    hyper_params['nifti_dir'] 
+                    / hyper_params["nifti_filename_pattern"]
                 )
             )
             filenames_flair = [os.path.basename(path) for path in nifti_paths_flair]
@@ -121,8 +121,8 @@ def main(hyper_params):
                 filenames_flair = [f for f in filenames_flair if f.split('_')[0] in eids_normal]
                 filenames_seg = [f.replace('_flair.nii', '_seg.nii') for f in filenames_flair]
     
-                nifti_paths_flair = [hyper_params['nifti_flair_dir'] / name for name in filenames_flair]
-                nifti_paths_seg = [hyper_params['nifti_flair_dir'] / name for name in filenames_seg]
+                nifti_paths_flair = [hyper_params['nifti_dir'] / name for name in filenames_flair]
+                nifti_paths_seg = [hyper_params['nifti_dir'] / name for name in filenames_seg]
     
             nifti_b1000_filenames = filenames_flair
             nifti_b1000_paths = nifti_paths_flair

--- a/verydeepvae/orchestration/training_script_vae_new.py
+++ b/verydeepvae/orchestration/training_script_vae_new.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import random
 import torch
@@ -81,13 +82,13 @@ def main(hyper_params):
         else:
             misc.print_0(hyper_params, "Sequence type: " + hyper_params['sequence_type'])
             misc.print_0(hyper_params, f"nifti_flair_dir found in hyper_params: {hyper_params['nifti_flair_dir']}")
-            filenames = os.listdir(hyper_params['nifti_flair_dir'])
-            filenames = [f for f in filenames if not f.startswith('.')]  # Remove hidden files
-            filenames = [f for f in filenames if '_20253_2_0.zip' in f]  # Remove hidden files
-            filenames_flair = [f for f in filenames if '_flair' in f]
-    
-            nifti_paths_flair = [hyper_params['nifti_flair_dir'] / name for name in filenames_flair]
-
+            nifti_paths_flair = glob.glob(
+                str(
+                    hyper_params['nifti_flair_dir'] 
+                    / hyper_params["nifti_flair_pattern"]
+                )
+            )
+            filenames_flair = [os.path.basename(path) for path in nifti_paths_flair]
             eids = [f.split('_')[0] for f in filenames_flair]
     
             if misc.key_is_true(hyper_params, 'load_metadata'):


### PR DESCRIPTION
Adds a script to generate a random synthetic training dataset of volumetric images as NIfTI files. The generated volumetric images consist of randomly oriented and sized ellipsoid inclusions overlaid with Gaussian filtered background noise. The script allows specifying the number of files to generate, their resolution and parameters controlling the noise amplitude and length scale, and difference between ellipsoid inclusion and background.

To allow training with synthetic datasets, the previous logic for selecting the files in the directory specified by the `nifti_flair_dir` (now renamed to `nifti_dir`) argument to the training script to use for training, has been replaced with using [`glob.glob`](https://docs.python.org/3/library/glob.html#glob.glob) to pattern match the filenames based on file name pattern specified by a new optional `nifti_filename_pattern` argument to the training script (defaulting to `*.nii`).