### PR TITLE
Add integration tests and associated GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
     name: Run tests with Python ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v3
+      - name: List checked out files
+        shell: bash
+        run: ls -R
       - name: Get tox environment name
         id: tox-env
         uses: actions/github-script@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: "pip"
           cache-dependency-path: |
-            "requirements/${{ steps.tox-env.outputs.result }}-requirements.txt"
+            "**/${{ steps.tox-env.outputs.result }}-requirements.txt"
       - name: Install tox
         run: pip install tox
       - name: Get system information

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           script: |
             let version_code = '${{ matrix.python }}'.split('.').join('');
-            return `py-${version_code}-linux`;
+            return `py${version_code}-linux`;
           result-encoding: string
       - name: Setup Python
         uses: actions/setup-python@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
-          cache-dependency-path: "requirements/${{ steps.tox-env.result }}-requirements.txt"
+          cache-dependency-path: |
+            "requirements/${{ steps.tox-env.outputs.result }}-requirements.txt"
       - name: Install tox
         run: pip install tox
       - name: Get system information
@@ -44,7 +45,7 @@ jobs:
           pip --version
           tox --version
       - name: Run tests
-        run: tox -v -e ${{ steps.tox-env.result }}
+        run: tox -v -e ${{ steps.tox-env.outputs.result }}
         
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,13 @@ jobs:
       - name: Copy requirements file
         shell: bash
         run: |
-          cp requirements/${{ steps.tox-env.outputs.result }}-requirements.txt .
+          cp requirements/${{ steps.tox-env.outputs.result }}-requirements.txt requirements.txt
           ls -R
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
-          cache-dependency-path: |
-            "${{ steps.tox-env.outputs.result }}-requirements.txt"
       - name: Install tox
         run: pip install tox
       - name: Get system information

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
     name: Run tests with Python ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v3
-      - name: List checked out files
-        shell: bash
-        run: ls -R
       - name: Get tox environment name
         id: tox-env
         uses: actions/github-script@v4
@@ -30,13 +27,18 @@ jobs:
             let version_code = '${{ matrix.python }}'.split('.').join('');
             return `py${version_code}-linux`;
           result-encoding: string
+      - name: Copy requirements file
+        shell: bash
+        run: |
+          cp requirements/${{ steps.tox-env.outputs.result }}-requirements.txt .
+          ls -R
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"
           cache-dependency-path: |
-            "**/${{ steps.tox-env.outputs.result }}-requirements.txt"
+            "${{ steps.tox-env.outputs.result }}-requirements.txt"
       - name: Install tox
         run: pip install tox
       - name: Get system information

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         python: ["3.7", "3.8", "3.9"]
     name: Run tests with Python ${{ matrix.python }}
     steps:
@@ -46,19 +46,19 @@ jobs:
       - name: Run tests
         run: tox -v -e ${{ steps.tox-env.result }}
         
-    checks:
-      runs-on: ubuntu-latest
-      strategy:
-        fail-fast: false
-      name: Run checks with Python 3.9
-      steps:
-        - uses: actions/checkout@v3
-        - name: Setup Python
-          uses: actions/setup-python@v3
-          with:
-            python-version: "3.9"
-        - name: Install tox
-          run: pip install tox
-        - name: Run checks
-          run: tox -v -e check
+  checks:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: Run checks with Python 3.9
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install tox
+        run: pip install tox
+      - name: Run checks
+        run: tox -v -e check
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+
+name: Continuous integration
+
+on:
+  push:
+    branches: "main"
+  pull_request:
+  schedule:
+    - cron: 0 0 * * 0
+
+jobs:
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fail-fast: false
+        python: ["3.7", "3.8", "3.9"]
+    name: Run tests with Python ${{ matrix.python }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get tox environment name
+        id: tox-env
+        uses: actions/github-script@v4
+        with:
+          script: |
+            let version_code = '${{ matrix.python }}'.split('.').join('');
+            return `py-${version_code}-linux`;
+          result-encoding: string
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+          cache: "pip"
+          cache-dependency-path: "requirements/${{ steps.tox-env.result }}-requirements.txt"
+      - name: Install tox
+        run: pip install tox
+      - name: Get system information
+        run: |
+          set -x
+          uname -a
+          lsb_release -a
+          python --version
+          pip --version
+          tox --version
+      - name: Run tests
+        run: tox -v -e ${{ steps.tox-env.result }}
+        
+    checks:
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+      name: Run checks with Python 3.9
+      steps:
+        - uses: actions/checkout@v3
+        - name: Setup Python
+          uses: actions/setup-python@v3
+          with:
+            python-version: "3.9"
+        - name: Install tox
+          run: pip install tox
+        - name: Run checks
+          run: tox -v -e check
+    

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 graft requirements
 include tox.ini
+include CITATION.cff
 recursive-exclude .idea *
 recursive-include example_configurations *.json
 recursive-include scripts *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include CITATION.cff
 recursive-exclude .idea *
 recursive-include example_configurations *.json
 recursive-include scripts *.py
+recursive-include tests *.py

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,197 @@
+"""Run integration tests with data generation and training scripts"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SEED = 7856391
+
+
+def run_script(script_filename, script_args, check_return_code=False):
+    script_path = Path(__file__).parent.parent / "scripts" / script_filename
+    assert script_path.exists(), f"Cannot find script at {script_path}"
+    command_args = [sys.executable, str(script_path.resolve())] + script_args
+    completed_process = subprocess.run(
+        command_args, encoding="utf8", capture_output=True
+    )
+    if check_return_code:
+        assert completed_process.returncode == 0, (
+            f"Running {' '.join(command_args)} fails to successfully complete "
+            f"with stderr output\n\n{completed_process.stderr}"
+        )
+    return completed_process
+
+
+@pytest.mark.parametrize("voxels_per_axis", [8, 16, 32])
+@pytest.mark.parametrize("number_of_files", [10, 100])
+def test_generate_synthetic_data(tmp_path, voxels_per_axis, number_of_files):
+    script_args = [
+        "--voxels_per_axis",
+        str(voxels_per_axis),
+        "--number_of_files",
+        str(number_of_files),
+        "--output_directory",
+        str(tmp_path),
+        "--random_seed",
+        str(SEED),
+    ]
+    run_script("generate_synthetic_data.py", script_args, check_return_code=True)
+    assert len(list(tmp_path.glob("ellipsoid_*.nii"))) == number_of_files
+
+
+@pytest.mark.parametrize("number_of_files", [-1, 0])
+def test_generate_synthetic_data_non_valid_number_of_files_fails(
+    tmp_path, number_of_files
+):
+    script_args = [
+        "--voxels_per_axis",
+        "8",
+        "--number_of_files",
+        str(number_of_files),
+        "--output_directory",
+        str(tmp_path),
+        "--random_seed",
+        str(SEED),
+    ]
+    completed_process = run_script("generate_synthetic_data.py", script_args)
+    assert completed_process.returncode != 0
+    assert "number_of_files must be a positive integer" in str(completed_process.stderr)
+
+
+@pytest.mark.parametrize("voxels_per_axis", [-1, 0, 7])
+def test_generate_synthetic_data_non_valid_resolution_fails(tmp_path, voxels_per_axis):
+    script_args = [
+        "--voxels_per_axis",
+        str(voxels_per_axis),
+        "--number_of_files",
+        "10",
+        "--output_directory",
+        str(tmp_path),
+        "--random_seed",
+        str(SEED),
+    ]
+    completed_process = run_script("generate_synthetic_data.py", script_args)
+    assert completed_process.returncode != 0
+    assert "voxels_per_image must be a positive power of two" in str(
+        completed_process.stderr
+    )
+
+
+@pytest.fixture
+def configuration_dict():
+    return {
+        "random_seed": SEED,
+        "total_epochs": 1,
+        "batch_size": 1,
+        "max_niis_to_use": 2,
+        "plot_recons_period": 1,
+        "subjects_to_plot": 4,
+        "validation_period": 1,
+        "save_period": 1,
+        "warmup_iterations": 50,
+        "gradient_clipping_value": 100,
+        "gradient_skipping_value": 1000000000000,
+        "l2_reg_coeff": 1e-4,
+        "learning_rate": 1e-3,
+        "train_frac": 0.95,
+        "half_precision": False,
+        "print_model": False,
+        "use_tanh_output": True,
+        "new_model": True,
+        "use_abs_not_square": False,
+        "plot_gradient_norms": True,
+        "apply_mask_in_input_space": False,
+        "include_mask_in_loader": False,
+        "convolutional_downsampling": False,
+        "bottleneck_resnet_encoder": True,
+        "only_use_one_conv_block_at_top": False,
+        "normalise_weight_by_depth": True,
+        "zero_biases": True,
+        "use_rezero": False,
+        "veto_batch_norm": True,
+        "veto_transformations": False,
+        "apply_augmentations_to_validation_set": False,
+        "visualise_training_pipeline_before_starting": True,
+        "discard_abnormally_small_niftis": True,
+        "use_nii_data": True,
+        "nifti_standardise": True,
+        "shuffle_niftis": False,
+        "save_recons_to_mat": False,
+        "use_DDP": True,
+        "base_recons_on_train_loader": False,
+        "resume_from_checkpoint": False,
+        "restore_optimiser": True,
+        "keep_every_checkpoint": True,
+        "predict_x_var": True,
+        "predict_x_var_with_sigmoid": True,
+        "use_precision_reweighting": False,
+        "separate_hidden_loc_scale_convs": False,
+        "separate_output_loc_scale_convs": False,
+        "verbose": True,
+        "variance_hidden_clamp_bounds": [0.001, 1],
+        "variance_output_clamp_bounds": [0.01, 1],
+        "nii_target_shape": [32, 32, 32],
+        "latents_per_channel": [2, 4, 4, 3, 2, 1],
+        "channels_per_latent": [10, 10, 10, 10, 10, 50],
+        "channels": [10, 20, 30, 40, 50, 60],
+        "kernel_sizes_bottom_up": [3, 3, 3, 3, 2, 1],
+        "kernel_sizes_top_down": [3, 3, 3, 3, 2, 1],
+        "channels_hidden": [10, 20, 30, 40, 50, 60],
+        "channels_top_down": [10, 20, 30, 40, 50, 60],
+        "channels_hidden_top_down": [10, 20, 30, 40, 50, 60],
+        "latents_per_channel_weight_sharing": "none",
+        "latents_to_use": "all",
+        "latents_to_optimise": "all",
+        "sequence_type": "flair",
+        "likelihood": "Gaussian",
+    }
+
+
+@pytest.mark.parametrize(
+    "configuration_updates",
+    [
+        {},
+        {"total_epochs": 2},
+        {"half_precision": True},
+        {"print_model": True},
+        {"verbose": False},
+        {"save_recons_to_mat": True},
+        {"shuffle_nifitis": True},
+    ],
+    ids=lambda d: ",".join(f"{k}={v}" for k, v in d.items()) if d else "base"
+)
+def test_generate_synthetic_data_and_train_vae_model(
+    tmp_path_factory, configuration_dict, configuration_updates
+):
+    voxels_per_axis = 32
+    number_of_files = 2
+    data_dir = tmp_path_factory.mktemp("data")
+    generate_data_args = [
+        "--voxels_per_axis",
+        str(voxels_per_axis),
+        "--number_of_files",
+        str(number_of_files),
+        "--output_directory",
+        str(data_dir),
+        "--random_seed",
+        str(SEED),
+    ]
+    run_script("generate_synthetic_data.py", generate_data_args, check_return_code=True)
+    configuration_dict.update(configuration_updates)
+    configuration_path = tmp_path_factory.mktemp("configurations") / "test_config.json"
+    with open(configuration_path, "w") as f:
+        json.dump(configuration_dict, f)
+    outputs_dir = tmp_path_factory.mktemp("outputs")
+    train_model_args = [
+        "--json_config_file",
+        str(configuration_path),
+        "--nifti_dir",
+        str(data_dir),
+        "--output_dir",
+        str(outputs_dir),
+    ]
+    run_script("train_vae_model.py", train_model_args, check_return_code=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,35 @@
 [tox]
 minversion = 2.0
 envlist = 
+    py{37,38,39}-{linux,windows}
     py{37,38,39}-{linux,windows}-requirements
     check
+
+
+[testenv:py{37,38,39}-{linux,windows}]
+platform = 
+    linux: linux
+    windows: win32
+deps =
+    -r{toxinidir}{/}requirements{/}{envname}-requirements.txt
+    # https://github.com/pytorch/pytorch/issues/69894
+    setuptools==59.5.0
+    pytest
+    pytest-cov
+commands =
+    pytest --cov={envsitepackagesdir}{/}verydeepvae --cov-append {posargs:-vv tests}
+depends =
+    py{37,38,39}-{linux,windows}: clean
+    report: py{37,38,39}-{linux,windows}
 
 
 [testenv:py{37,38,39}-{linux,windows}-requirements]
 platform = 
     linux: linux
     windows: win32
-
 deps = 
     pip-tools
-    
 skip_install = true
-
 commands=
     pip-compile --output-file {toxinidir}{/}requirements{/}{envname}.txt
 
@@ -28,3 +43,21 @@ commands =
     python setup.py sdist --formats=gztar
     twine check dist/*.tar.gz
     check-manifest {toxinidir}
+
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report
+    coverage html
+
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+allowlist_externals =
+    linux: rm
+commands = 
+    coverage erase
+    linux: rm -rf htmlcov


### PR DESCRIPTION
Fixes #19 

Adds some basic integration tests using pytest, with the data generation and model training scripts in the `scripts` directory called using `subprocess`. The generation script tests check that the generation script creates files when given valid inputs and fails with an appropriate error message when passed invalid arguments. There is also a test which sequentially calls the generation script and then model training script (passing the generated data directory), running training for a base model configuration at 32x32x32 resolution for 1 epoch (with runs also performed for a small set of variations to this base configuration).

Environments for running the tests and generating a coverage report are also added to the `tox.ini` file and a GitHub Actions workflow YAML file added to automatically run the tests (and other checks previously added to the `tox.ini` file) on every push to main, on pull-requests and on a weekly schedule.