### PR TITLE
Only close `writer` object when not `None`

### DIFF
--- a/verydeepvae/orchestration/training_script_vae_new.py
+++ b/verydeepvae/orchestration/training_script_vae_new.py
@@ -934,4 +934,5 @@ def main(hyper_params):
                     # data_dictionary_1 is left over from the recon logic and is used each time we sample
                     del data_dictionary_1
 
-    writer.close()
+    if hyper_params['local_rank'] == 0:
+        writer.close()

--- a/verydeepvae/orchestration/training_script_vae_new.py
+++ b/verydeepvae/orchestration/training_script_vae_new.py
@@ -934,5 +934,5 @@ def main(hyper_params):
                     # data_dictionary_1 is left over from the recon logic and is used each time we sample
                     del data_dictionary_1
 
-    if hyper_params['local_rank'] == 0:
+    if writer is not None:
         writer.close()


### PR DESCRIPTION
Fixes #32 

Wraps `writer.close()` call in an `if` block that only executes if the `writer` object is not `None` (which should only be the case on the rank 0 process). 
